### PR TITLE
Move DecoratorsHelper into Dekorator::Controller to improve railtie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Moved to Komposable organization ([#13](https://github.com/komposable/dekorator/pull/13))
 - Replace Travis CI by Github Actions and remove ruby 2.3 support ([#23](https://github.com/komposable/dekorator/pull/23))
+- Update railtie to not trigger initialization autoloaded constant deprecation warning ([#30](https://github.com/komposable/dekorator/pull/30))
 
 ### Fixes
 - Fix DecoratedEnumerableProxy for Rails 6 ([5a656333](https://github.com/komposable/dekorator/commit/5a656333e9ca6321d0474f0e54de4332219b88d0))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Moved to Komposable organization ([#13](https://github.com/komposable/dekorator/pull/13))
 - Replace Travis CI by Github Actions and remove ruby 2.3 support ([#23](https://github.com/komposable/dekorator/pull/23))
-- Update railtie to not trigger initialization autoloaded constant deprecation warning ([#30](https://github.com/komposable/dekorator/pull/30))
+- Update railtie to prevent triggering initialization autoloaded constant deprecation warning ([#30](https://github.com/komposable/dekorator/pull/30))
 
 ### Fixes
 - Fix DecoratedEnumerableProxy for Rails 6 ([5a656333](https://github.com/komposable/dekorator/commit/5a656333e9ca6321d0474f0e54de4332219b88d0))

--- a/lib/dekorator.rb
+++ b/lib/dekorator.rb
@@ -67,7 +67,7 @@ module Dekorator
 
       def _decorate(object_or_enumerable, with: nil)
         if defined?(ActiveRecord::Relation) && object_or_enumerable.is_a?(ActiveRecord::Relation)
-          DecoratedEnumerableProxy.new(object_or_enumerable, with)
+          Dekorator::DecoratedEnumerableProxy.new(object_or_enumerable, with)
         elsif object_or_enumerable.is_a? Enumerable
           object_or_enumerable.map { |object| with.new(object) }
         else

--- a/lib/dekorator/rails/controller.rb
+++ b/lib/dekorator/rails/controller.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
+require "active_support/concern"
+
 module Dekorator
-  module DecoratorsHelper
+  module Controller
+    extend ActiveSupport::Concern
+
+    included do
+      helper_method :decorate
+    end
+
     def decorate(object_or_collection, with: nil)
       Dekorator::Base.decorate(object_or_collection, with: with)
     end

--- a/lib/dekorator/railtie.rb
+++ b/lib/dekorator/railtie.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
-require "dekorator/decorators_helper"
+require "dekorator/rails/controller"
 
 module Dekorator
   class Railtie < Rails::Railtie
-    initializer "decorators.helper" do |_app|
-      ActionView::Base.send :include, Dekorator::DecoratorsHelper
-      ActionController::Base.send :include, Dekorator::DecoratorsHelper
+    config.to_prepare do |_app|
+      ActionController::Base.include Dekorator::Controller
     end
 
     config.after_initialize do |app|


### PR DESCRIPTION
This change is to resolve the following message

```
DEPRECATION WARNING: Initialization autoloaded the constants ActionText::ContentHelper and ActionText::TagHelper.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload ActionText::ContentHelper, for example,
the expected changes won't be reflected in that stale Module object.

These autoloaded constants have been unloaded.

Please, check the "Autoloading and Reloading Constants" guide for solutions.
 (called from <top (required)> at /Users/nicolas/Projects/app/config/environment.rb:7)
```