### PR TITLE
Remove unnecessary eager load configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,10 +12,6 @@ Gemspec/OrderedDependencies:
 Style/BlockDelimiters:
   Enabled: true
 
-Style/BracesAroundHashParameters:
-  Enabled: true
-  EnforcedStyle: no_braces
-
 Style/Dir:
   Enabled: true
 

--- a/lib/dekorator/railtie.rb
+++ b/lib/dekorator/railtie.rb
@@ -7,9 +7,5 @@ module Dekorator
     config.to_prepare do |_app|
       ActionController::Base.include Dekorator::Controller
     end
-
-    config.after_initialize do |app|
-      app.config.paths.add "app/decorators", eager_load: true
-    end
   end
 end


### PR DESCRIPTION
Removing eager load configuration that is unnecessary since Rails already eager load every folder and files under `app` folder.